### PR TITLE
build(rollup): fixed build v-calendar

### DIFF
--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -315,7 +315,14 @@ const PLUGINS = [
   vue(),
   typescript({
     tsconfigOverride: { compilerOptions: { noImplicitAny: false } },
-    exclude: ["**/doc/**", "**/docs/**", "**/sandbox/**", "**/sandbox-nuxt/**", "**/**/*.test.ts"]
+    exclude: [
+      "**/doc/**",
+      "**/docs/**",
+      "**/sandbox/**",
+      "**/sandbox-nuxt/**",
+      "**/**/*.test.ts",
+      "**/node_modules/v-calendar/**"
+    ]
   }),
   postcss(POSTCSS_PLUGIN_OPTIONS),
   babel(BABEL_PLUGIN_OPTIONS),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Rollup config to exclude `**/node_modules/v-calendar/**` from the TypeScript plugin.
> 
> - **Build/ Rollup**:
>   - Update `lib/rollup.config.js` TypeScript plugin `exclude` list to add `**/node_modules/v-calendar/**`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bae14266cf32ee5d578ea5b9fa7d5d82b54499d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->