### PR TITLE
fix(pagination): disconnect ResizeObservers on unmount to prevent memory leak

### DIFF
--- a/Documentation/components/pagination.md
+++ b/Documentation/components/pagination.md
@@ -1,7 +1,7 @@
 ---
 title: Pagination
 summary: Пейджер с size-selector, info-text, кастомизируемым числом видимых страниц.
-updated: 2026-05-09
+updated: 2026-06-06
 stability: stable
 since: 0.2.11
 ---
@@ -251,7 +251,8 @@ describe("Pagination", () => {
 
 ### Incomplete or stubbed behavior
 
-- Coverage 98.42% statements / 72.05% branch — несколько ветвей не покрыты ([Pagination.vue:256](../../lib/pagination/Pagination.vue#L256)).
+- Coverage 98.42% statements / 72.05% branch — несколько ветвей не покрыты ([Pagination.vue:262](../../lib/pagination/Pagination.vue#L262)).
+- `ResizeObserver`'ы для short-navigation сохраняются в локальный массив `navigationObservers` и отключаются в `onBeforeUnmount` ([Pagination.vue:222-225](../../lib/pagination/Pagination.vue#L222-L225)) — утечки памяти при unmount нет (regression-тесты в [Pagination.test.ts](../../lib/pagination/Pagination.test.ts)).
 
 ### Skipped tests
 

--- a/Documentation/issues/README.md
+++ b/Documentation/issues/README.md
@@ -1,8 +1,8 @@
 ---
 title: Issues — Index
 summary: Сводный индекс аудит-документов компонентов и инфра-модулей FishtVue по 60-пунктовому чек-листу + Configuration support + Dual-API gap. Cross-cutting findings, fix roadmap с чекбоксами.
-updated: 2026-05-10
-last-changes: utilities — Issues 1, 2, 3, 5, 6, 7, 8, 10, 11 закрыты; severity matrix пересчитана; добавлен fix roadmap с чекбоксами.
+updated: 2026-06-06
+last-changes: pagination — Issue 1 (critical ResizeObserver leak) закрыт; severity matrix пересчитана (critical TOTAL 17→16); Wave 1.2 чекбокс отмечен.
 ---
 
 # Issues — Index
@@ -24,7 +24,7 @@ last-changes: utilities — Issues 1, 2, 3, 5, 6, 7, 8, 10, 11 закрыты; s
 | Calendar | [calendar.md](./calendar.md) | 1 | 6 | 4 | 3 |
 | TextEditor | [texteditor.md](./texteditor.md) | 0 | 7 | 5 | 3 |
 | Table | [table.md](./table.md) | 2 | 8 | 5 | 4 |
-| Pagination | [pagination.md](./pagination.md) | 1 | 4 | 4 | 3 |
+| Pagination | [pagination.md](./pagination.md) | 0 | 4 | 4 | 3 |
 | Badge | [badge.md](./badge.md) | 0 | 4 | 2 | 3 |
 | Form | [form.md](./form.md) | 1 | 6 | 4 | 3 |
 | InputLayout | [inputlayout.md](./inputlayout.md) | 2 | 4 | 4 | 3 |
@@ -43,9 +43,9 @@ last-changes: utilities — Issues 1, 2, 3, 5, 6, 7, 8, 10, 11 закрыты; s
 | Locale | [locale.md](./locale.md) | 0 | 5 | 4 | 2 |
 | Nuxt module | [nuxt-module.md](./nuxt-module.md) | 0 | 6 | 4 | 2 |
 | Utilities | [_utilities.md](./done/_utilities.md) | 0 | 1 | 0 | 1 |
-| **TOTAL** | **28 files** | **17** | **141** | **107** | **74** |
+| **TOTAL** | **28 files** | **16** | **141** | **107** | **74** |
 
-Всего **339 issues** распределены по 28 documentов аудита (9 закрыты в [_utilities.md](./done/_utilities.md) 2026-05-10: Issues 1, 2, 3, 5, 6, 7, 8, 10, 11).
+Всего **339 issues** распределены по 28 documentов аудита (10 закрыты: 9 в [_utilities.md](./done/_utilities.md) 2026-05-10 — Issues 1, 2, 3, 5, 6, 7, 8, 10, 11; [pagination.md](./pagination.md) Issue 1 — 2026-06-06).
 
 ## Fix roadmap (live tracker)
 
@@ -102,7 +102,7 @@ last-changes: utilities — Issues 1, 2, 3, 5, 6, 7, 8, 10, 11 закрыты; s
 - [ ] [Select.vue:286,291](../../lib/select/Select.vue#L286) — keydown listeners (`openSelectOnEnter`, `keydownSelect`) cleanup при unmount-while-open · [select.md Issue 2](./select.md)
 - [ ] [Calendar.vue:322-327](../../lib/calendar/Calendar.vue#L322) — `MutationObserver` на documentElement сохранить + disconnect · [calendar.md Issue 1](./calendar.md) · **рекомендация: вынести в singleton `useDarkMode()` composable** (один observer на весь app)
 - [ ] [Calendar.vue:254,261](../../lib/calendar/Calendar.vue#L254) — keydown listeners cleanup · [calendar.md Issue 1](./calendar.md)
-- [ ] [Pagination.vue:255](../../lib/pagination/Pagination.vue#L255) — anonymous `new ResizeObserver(...)` → сохранить в ref + disconnect · [pagination.md Issue 1](./pagination.md)
+- [x] [Pagination.vue:259-268](../../lib/pagination/Pagination.vue#L259-L268) — anonymous `new ResizeObserver(...)` → сохранён в массив + disconnect в `onBeforeUnmount` · ✅ resolved 2026-06-06 · [pagination.md Issue 1](./pagination.md)
 - [ ] [InputLayout.vue:177-179](../../lib/inputlayout/InputLayout.vue#L177) — anonymous ResizeObserver на `beforeInput` сохранить + disconnect · [inputlayout.md Issue 2](./inputlayout.md)
 - [ ] [InputLayout.vue:181-183](../../lib/inputlayout/InputLayout.vue#L181) — anonymous ResizeObserver на `afterInput` сохранить + disconnect · [inputlayout.md Issue 2](./inputlayout.md)
 - [ ] [Table.vue:1519-1527](../../lib/table/Table.vue#L1519) — `lastRowVisibleObserver` (IntersectionObserver) добавить в `onUnmounted` disconnect · [table.md Issue 2](./table.md)
@@ -499,7 +499,7 @@ Documentation [2.Theming.md](../../docs/content/ru/3.Configuration/2.Theming.md)
 **Memory leaks (observers/listeners без cleanup):**
 - Select ResizeObserver + keydown listeners ([select.md Issue 2](./select.md))
 - Calendar MutationObserver на documentElement ([calendar.md Issue 1](./calendar.md))
-- Pagination anonymous ResizeObserver ([pagination.md Issue 1](./pagination.md))
+- ~~Pagination anonymous ResizeObserver~~ ✅ resolved 2026-06-06 ([pagination.md Issue 1](./pagination.md))
 - InputLayout 2× anonymous ResizeObservers ([inputlayout.md Issue 2](./inputlayout.md))
 - Table IntersectionObserver + window mousemove/up partial cleanup ([table.md Issue 2](./table.md))
 - Dialog escapeListener при unmount-while-open ([dialog.md Issue 2](./dialog.md))

--- a/Documentation/issues/pagination.md
+++ b/Documentation/issues/pagination.md
@@ -1,7 +1,7 @@
 ---
 title: Issues — Pagination
 summary: Аудит Pagination — memory leak (anonymous ResizeObserver без cleanup), нет ARIA navigation роли, RTL, виртуализация для много-страничной нумерации.
-updated: 2026-05-10
+updated: 2026-06-06
 audit-checklist: 60-point + Configuration support + Dual-API gap
 source: lib/pagination/
 related-doc: ../components/pagination.md
@@ -13,16 +13,18 @@ related-doc: ../components/pagination.md
 
 | Severity | Count | Categories |
 |---|---|---|
-| critical | 1 | H41 (anonymous ResizeObserver leak) |
+| critical | 0 | ~~H41 (anonymous ResizeObserver leak)~~ ✅ resolved |
 | high | 4 | A2, A4-5, C17, L53 |
 | medium | 4 | E29.1, E29.5, F31, G34 |
 | low | 3 | E29.7, B10, N59 |
 
-## Issue 1: CRITICAL — Анонимный ResizeObserver без cleanup
+## ~~Issue 1: CRITICAL — Анонимный ResizeObserver без cleanup~~ ✅ resolved (2026-06-06)
 
 - **Категория:** H41 (memory leaks)
-- **Severity:** **critical**
-- **Где:** [Pagination.vue:253-258](../../lib/pagination/Pagination.vue#L253-L258)
+- **Severity:** ~~critical~~ → resolved
+- **Где:** [Pagination.vue:259-268](../../lib/pagination/Pagination.vue#L259-L268)
+
+> **Resolved (2026-06-06):** observer'ы теперь сохраняются в локальный массив `navigationObservers` ([Pagination.vue:33](../../lib/pagination/Pagination.vue#L33)) и отключаются в `onBeforeUnmount` ([Pagination.vue:222-225](../../lib/pagination/Pagination.vue#L222-L225)). Массив — обычный (не `ref`): reactive-proxy ломал внутренний WeakMap-lookup полифилла при `disconnect()`. Regression-тесты — `Pagination.test.ts` describe «ResizeObserver cleanup (memory leak guard)».
 
 ### Что найдено
 
@@ -62,8 +64,8 @@ function setShortNavigation(link: HTMLElement, limit: number, refButton: Ref) {
 
 ### Acceptance criteria
 
-- [ ] `onBeforeUnmount` вызывает disconnect.
-- [ ] Профилирование DevTools heap не растёт.
+- [x] `onBeforeUnmount` вызывает disconnect. ✅ ([Pagination.vue:222-225](../../lib/pagination/Pagination.vue#L222-L225))
+- [x] Профилирование DevTools heap не растёт. ✅ (proxy через тест: disconnect-count масштабируется по mount/unmount циклам)
 
 ## Issue 2: SSR styles + sideEffects/exports map
 

--- a/lib/pagination/Pagination.test.ts
+++ b/lib/pagination/Pagination.test.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import FishtVue from "fishtvue/config"
 import Pagination from "fishtvue/pagination/Pagination.vue"
 import { nextTick } from "vue"
@@ -221,6 +221,56 @@ describe("Pagination Component Tests", () => {
       })
     })
   })
+  describe("Pagination Component - ResizeObserver cleanup (memory leak guard)", () => {
+    it("observes both navigation links on mount and does not disconnect early", () => {
+      const observeSpy = vi.spyOn(global.ResizeObserver.prototype, "observe")
+      const disconnectSpy = vi.spyOn(global.ResizeObserver.prototype, "disconnect")
+
+      const wrapper = mount(Pagination, {
+        props: { modelValue: 1, total: 100, sizePage: 10 }
+      })
+
+      // оба nav-link (previous + next) должны наблюдаться
+      expect(observeSpy).toHaveBeenCalledTimes(2)
+      expect(disconnectSpy).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+      observeSpy.mockRestore()
+      disconnectSpy.mockRestore()
+    })
+
+    it("disconnects every ResizeObserver on unmount", () => {
+      const disconnectSpy = vi.spyOn(global.ResizeObserver.prototype, "disconnect")
+
+      const wrapper = mount(Pagination, {
+        props: { modelValue: 1, total: 100, sizePage: 10 }
+      })
+      expect(disconnectSpy).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+      // оба observer'а отключены — heap не растёт
+      expect(disconnectSpy).toHaveBeenCalledTimes(2)
+
+      disconnectSpy.mockRestore()
+    })
+
+    it("scales disconnect count across repeated mount/unmount cycles", () => {
+      const disconnectSpy = vi.spyOn(global.ResizeObserver.prototype, "disconnect")
+
+      for (let i = 0; i < 5; i++) {
+        const wrapper = mount(Pagination, {
+          props: { modelValue: 1, total: 100, sizePage: 10 }
+        })
+        expect(() => wrapper.unmount()).not.toThrow()
+      }
+
+      // 5 циклов × 2 observer'а = 10 disconnect-вызовов
+      expect(disconnectSpy).toHaveBeenCalledTimes(10)
+
+      disconnectSpy.mockRestore()
+    })
+  })
+
   describe("Pagination Component - With Library Initialization", () => {
     const createAppWithFishtVue = (options = {}) => ({
       install(app: any) {

--- a/lib/pagination/Pagination.vue
+++ b/lib/pagination/Pagination.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import type { Ref } from "vue"
-  import { computed, onMounted, ref, watch } from "vue"
+  import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue"
   import {
     ArrowLongLeftIcon,
     ArrowLongRightIcon,
@@ -30,6 +30,7 @@
   const sizePage = ref<number>()
   const isShortPrevious = ref(false)
   const isShortNext = ref(false)
+  const navigationObservers: ResizeObserver[] = []
   // ---PROPS-------------------------------
   const sizePageProp = computed<NonNullable<PaginationProps["sizePage"]>>(() => {
     const sizePageProp = (props.sizePage as PaginationProps["sizePage"]) ?? options?.sizePage ?? 5
@@ -218,6 +219,11 @@
       setShortNavigation(navNextLink.value, limit, isShortNext)
     }
   })
+  onBeforeUnmount(() => {
+    // отключаем все ResizeObserver'ы при размонтировании
+    navigationObservers.forEach((observer) => observer.disconnect())
+    navigationObservers.length = 0
+  })
   // ---WATCHERS----------------------------
   watch(sizePageProp, (value) => (sizePage.value = value), {
     immediate: true
@@ -251,10 +257,14 @@
   }
 
   function setShortNavigation(link: HTMLElement, limit: number, refButton: Ref) {
-    if (link)
-      new ResizeObserver((entries) => {
+    if (link) {
+      // сохраняем observer, чтобы отключить его в onBeforeUnmount (иначе утечка памяти)
+      const observer = new ResizeObserver((entries) => {
         for (const entry of entries) refButton.value = (entry as any)?.target["offsetWidth"] < limit
-      }).observe(link)
+      })
+      observer.observe(link)
+      navigationObservers.push(observer)
+    }
   }
 </script>
 


### PR DESCRIPTION
## Что сделано

Закрывает **критический** issue из аудита: [`Documentation/issues/pagination.md` Issue 1](Documentation/issues/pagination.md) (H41 — memory leak, Wave 1.2).

`setShortNavigation` создавал анонимный `new ResizeObserver(...)`, инстанс которого нигде не сохранялся → его невозможно было `disconnect()`, а `onBeforeUnmount`-хука не было вовсе. В long-lived дашбордах с десятками таблиц (Pagination живёт в Table footer) это накапливало висящие observer'ы.

### Fix
- Observer'ы сохраняются в локальный массив `navigationObservers` и отключаются в `onBeforeUnmount`.
- Массив — **обычный**, не `ref`: реактивный proxy оборачивает инстанс observer'а и ломает внутренний WeakMap-lookup полифилла при `disconnect()` (соответствует канону `dev-patterns.md §2`: «нет реактивности — нет смысла в `ref`»).
- Публичный API (`Props`/`Emits`/`Slots`/`Expose`) не меняется.

## Тесты
`lib/pagination/Pagination.test.ts` — добавлен describe «ResizeObserver cleanup (memory leak guard)», 3 кейса:
- observe ×2 на mount, без раннего disconnect;
- disconnect ×2 на unmount;
- disconnect-count масштабируется по 5 циклам mount/unmount (proxy для heap-stable).

**31/31 green** (28 исходных не тронуты). Регрессия в основном потребителе (Table) — 66/66 green.

## Документация
- `Documentation/issues/pagination.md` — Issue 1 зачёркнут + `✅ resolved`, acceptance отмечен, матрица critical 1→0.
- `Documentation/issues/README.md` — строка Pagination critical 1→0, TOTAL critical 17→16, Wave 1.2 чекбокс отмечен, cross-cutting запись зачёркнута.
- `Documentation/components/pagination.md` — §18 anchor поправлен + заметка о cleanup.

## Verification
- `vue-tsc --noEmit --skipLibCheck`: ✓
- `vitest run Pagination.test.ts`: ✓ 31 passed
- `vitest run Table.test.ts`: ✓ 66 passed
- `eslint --fix` + `prettier --write`: ✓ clean

https://claude.ai/code/session_01PYjVRAmW55RH6hxXxmEEmQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYjVRAmW55RH6hxXxmEEmQ)_